### PR TITLE
update pe submission claim format designation

### DIFF
--- a/schemas/presentation-submission-claim-format-designations.json
+++ b/schemas/presentation-submission-claim-format-designations.json
@@ -2,10 +2,10 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Presentation Submission Claim Format Designations",
   "type": "object",
-  "properties": {
-  "format": {
+  "definitions": {
+    "format": {
       "type": "string",
       "enum": ["jwt", "jwt_vc", "jwt_vp", "ldp", "ldp_vc", "ldp_vp"]
-   }
+    }
   }
 }

--- a/schemas/presentation-submission-claim-format-designations.json
+++ b/schemas/presentation-submission-claim-format-designations.json
@@ -2,11 +2,10 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Presentation Submission Claim Format Designations",
   "type": "object",
-  "additionalProperties": false,
   "properties": {
-      "format": {
-        "enum": ["jwt", "jwt_vc", "jwt_vp", "ldp", "ldp_vc", "ldp_vp"]
-      }
-    }
+  "format": {
+      "type": "string",
+      "enum": ["jwt", "jwt_vc", "jwt_vp", "ldp", "ldp_vc", "ldp_vp"]
+   }
   }
 }


### PR DESCRIPTION
after testing, discovered this is the proper way to structure a single property. enforcement is handled in the main schema it's used in.